### PR TITLE
Add game speed runtime option and env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+.vs/
 
 # Build results
 [Dd]ebug/

--- a/bwheadless.vcxproj
+++ b/bwheadless.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -10,12 +10,13 @@
     <ProjectGuid>{2B04FFDC-5E9C-4E73-921C-109DB247620E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>bwheadless</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -40,6 +41,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -52,12 +54,14 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="codegen.h" />
+    <ClInclude Include="game_speed.h" />
     <ClInclude Include="load_pe.h" />
     <ClInclude Include="sc_hook.h" />
     <ClInclude Include="strf.h" />
     <ClInclude Include="x86dec.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="game_speed.cpp" />
     <ClCompile Include="inject.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="sc_hook.cpp" />

--- a/bwheadless.vcxproj.filters
+++ b/bwheadless.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="strf.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="game_speed.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="inject.cpp">
@@ -39,6 +42,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="sc_hook.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="game_speed.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/game_speed.cpp
+++ b/game_speed.cpp
@@ -1,0 +1,73 @@
+#include "game_speed.h"
+
+GameSpeed::GameSpeed(const int value, const std::string &name)
+	: _value(value)
+	, _name(name)
+{}
+
+std::optional<int> GameSpeed::parse(const std::string &name, const bool caseSensitive) {
+	auto nameCopy = name;
+
+	if (!caseSensitive) {
+		nameCopy = to_upper(name);
+	}
+
+	for (const auto &type : getAllGameSpeeds()) {
+		auto typeNameCopy = type.getName();
+
+		if (!caseSensitive) {
+			typeNameCopy = to_upper(typeNameCopy);
+		}
+
+		if (typeNameCopy == nameCopy) {
+			return type.intValue();
+		}
+	}
+	return {};
+}
+
+std::optional<std::string> GameSpeed::parse(const int value) {
+	for (const auto &type : getAllGameSpeeds()) {
+		if (type.intValue() == value) {
+			return type.getName();
+		}
+	}
+	return {};
+}
+
+std::string GameSpeed::to_upper(const std::string &str) {
+	std::string upper("");
+
+	const int uoffset = 'a' - 'A';
+
+	for (size_t i = 0; i < str.length(); ++i) {
+		char ch = str[i];
+		if (ch >= 'a' && ch <= 'z') {
+			ch -= uoffset;
+		}
+		upper += ch;
+	}
+
+	return upper;
+}
+
+const GameSpeed GameSpeed::SLOWEST(0, "Slowest");
+const GameSpeed GameSpeed::SLOWER(1, "Slower");
+const GameSpeed GameSpeed::SLOW(2, "Slow");
+const GameSpeed GameSpeed::NORMAL(3, "Normal");
+const GameSpeed GameSpeed::FAST(4, "Fast");
+const GameSpeed GameSpeed::FASTER(5, "Faster");
+const GameSpeed GameSpeed::FASTEST(6, "Fastest");
+std::vector<GameSpeed> GameSpeed::getAllGameSpeeds() {
+	const auto &all = {
+		GameSpeed::SLOWEST,
+		GameSpeed::SLOWER,
+		GameSpeed::SLOW,
+		GameSpeed::NORMAL,
+		GameSpeed::FAST,
+		GameSpeed::FASTER,
+		GameSpeed::FASTEST
+	};
+	return all;
+}
+

--- a/game_speed.h
+++ b/game_speed.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+class GameSpeed {
+public:
+	GameSpeed() = delete;
+	GameSpeed(const int value, const std::string &name);
+
+	int intValue() const noexcept { return _value; }
+	std::string getName() const noexcept { return _name; }
+
+	static const GameSpeed SLOWEST;
+	static const GameSpeed SLOWER;
+	static const GameSpeed SLOW;
+	static const GameSpeed NORMAL;
+	static const GameSpeed FAST;
+	static const GameSpeed FASTER;
+	static const GameSpeed FASTEST;
+	static std::vector<GameSpeed> getAllGameSpeeds();
+
+	static std::optional<int> parse(const std::string &name, const bool caseSensitive = false);
+	static std::optional<std::string> parse(const int value);
+
+private:
+	const int _value;
+	const std::string _name;
+
+	static std::string to_upper(const std::string &str);
+};


### PR DESCRIPTION
This commit addresses https://github.com/Games-and-Simulations/sc-docker/issues/75.

**Important:** Please answer these questions before merging and using with sc-docker: Where did you get the `bwheadless.exe` file that is currently used in sc-docker? Did you compile bwheadless yourself from this repo? If not, you will need to be aware that tscmoo's repo does not contain the source for the `bwheadless.exe` that is floating around. One major difference is that the LAN network provider option is broken in this repo. Let me know if you use the `--lan` option and I will submit a PR for that, too.